### PR TITLE
feat: add disbursement API with audit logging

### DIFF
--- a/app/api/routes/__init__.py
+++ b/app/api/routes/__init__.py
@@ -1,7 +1,7 @@
 """Top level API router registration."""
 from fastapi import APIRouter, FastAPI
 
-from app.api.routes import auth, dividends, health, plans, proxy, shareholders
+from app.api.routes import auth, dividends, health, plans, proxy, shareholders, transactions
 
 
 def register_routes(application: FastAPI) -> None:
@@ -14,6 +14,7 @@ def register_routes(application: FastAPI) -> None:
     api_router.include_router(shareholders.router, prefix="/shareholders", tags=["shareholders"])
     api_router.include_router(dividends.router, tags=["dividends"])
     api_router.include_router(proxy.router, tags=["proxy"])
+    api_router.include_router(transactions.router, tags=["transactions"])
 
     application.include_router(api_router)
 

--- a/app/api/routes/transactions.py
+++ b/app/api/routes/transactions.py
@@ -1,0 +1,75 @@
+"""Transaction-related API routes."""
+from __future__ import annotations
+
+from decimal import Decimal
+from uuid import uuid4
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from sqlalchemy.orm import Session
+
+from app.api.deps import get_db_session
+from app.api.routes.auth import AuthenticatedUser, require_role
+from app.schemas.transaction import DisbursementRequest, DisbursementResponse
+from app.services.disbursements import (
+    DisbursementAdapterError,
+    DisbursementConcurrencyError,
+    DisbursementPayload,
+    DisbursementService,
+    ShareholderKYCError,
+    ShareholderNotFoundError,
+)
+
+router = APIRouter(prefix="/transactions")
+
+
+@router.post("/disburse", response_model=DisbursementResponse, status_code=status.HTTP_201_CREATED)
+def create_disbursement(
+    payload: DisbursementRequest,
+    request: Request,
+    session: Session = Depends(get_db_session),
+    user: AuthenticatedUser = Depends(require_role("ADMIN", "OPS", "COMPLIANCE")),
+) -> DisbursementResponse:
+    request_id = getattr(request.state, "request_id", None) or uuid4().hex
+    request.state.request_id = request_id
+    request.state.actor_email = user.email
+    request.state.tenant_id = user.tenant_id
+
+    service = DisbursementService(session)
+    disbursement_payload = DisbursementPayload(
+        shareholder_id=payload.shareholder_id,
+        amount=Decimal(payload.amount),
+        currency=payload.currency,
+        memo=payload.memo,
+        bank_account_number=payload.bank_account_number,
+        bank_routing_number=payload.bank_routing_number,
+    )
+
+    try:
+        transaction = service.disburse(
+            tenant_id=user.tenant_id,
+            payload=disbursement_payload,
+            actor_email=user.email,
+            request_id=request_id,
+        )
+    except ShareholderNotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    except ShareholderKYCError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    except DisbursementAdapterError as exc:
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=str(exc)) from exc
+    except DisbursementConcurrencyError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+
+    response = DisbursementResponse(
+        transaction_id=transaction.id,
+        status=transaction.status,
+        amount=Decimal(transaction.amount),
+        currency=transaction.currency,
+        shareholder_id=transaction.shareholder_id or "",
+        lock_version=transaction.lock_version,
+        request_id=request_id,
+    )
+    return response
+
+
+__all__ = ["create_disbursement", "router"]

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -25,6 +25,15 @@ class Settings(BaseSettings):
     database_url: str = Field(default="postgresql+psycopg://fintech:fintech@db:5432/fintech")
     redis_url: str = Field(default="redis://redis:6379/0")
 
+    aws_region: str = Field(default="us-east-1")
+    s3_endpoint_url: str | None = Field(default=None)
+    audit_log_bucket: str = Field(default="fintech-audit-logs")
+    audit_log_prefix: str = Field(default="audit/records")
+    audit_log_sample_rate: float = Field(default=1.0)
+
+    ach_adapter_url: str = Field(default="http://localhost:9010/ach/disburse")
+    ach_adapter_timeout_seconds: float = Field(default=5.0)
+
     jwt_algorithm: str = Field(default="RS256")
     jwt_private_key: str = Field(default_factory=_load_default_private_key)
     access_token_expire_minutes: int = Field(default=15)

--- a/app/main.py
+++ b/app/main.py
@@ -6,6 +6,7 @@ from fastapi import FastAPI
 from app.api.routes import register_routes
 from app.core.config import Settings, get_settings
 from app.core.logging import configure_logging
+from app.obs import AuditMiddleware
 
 
 def create_application(settings: Settings | None = None) -> FastAPI:
@@ -21,6 +22,7 @@ def create_application(settings: Settings | None = None) -> FastAPI:
         openapi_url=settings.openapi_url,
     )
 
+    application.add_middleware(AuditMiddleware, settings=settings)
     register_routes(application)
 
     return application

--- a/app/models/shareholder.py
+++ b/app/models/shareholder.py
@@ -5,7 +5,7 @@ import enum
 import uuid
 
 from sqlalchemy import Enum as SAEnum
-from sqlalchemy import ForeignKey, Index, JSON, Numeric, String, UniqueConstraint
+from sqlalchemy import Boolean, ForeignKey, Index, JSON, Numeric, String, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.models.base import Base, TimestampMixin
@@ -40,6 +40,7 @@ class Shareholder(TimestampMixin, Base):
     )
     total_shares: Mapped[float] = mapped_column(Numeric(18, 4), nullable=False, default=0)
     profile: Mapped[dict | None] = mapped_column(JSON)
+    kyc_verified: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
 
     tenant = relationship("Tenant", back_populates="shareholders")
     plans = relationship("EmployeePlan", back_populates="shareholder")

--- a/app/models/transaction.py
+++ b/app/models/transaction.py
@@ -5,7 +5,7 @@ import enum
 import uuid
 
 from sqlalchemy import Enum as SAEnum
-from sqlalchemy import ForeignKey, Index, JSON, Numeric, String
+from sqlalchemy import ForeignKey, Index, Integer, JSON, Numeric, String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.models.base import Base, TimestampMixin
@@ -51,10 +51,13 @@ class Transaction(TimestampMixin, Base):
     )
     reference: Mapped[str | None] = mapped_column(String(128))
     details: Mapped[dict | None] = mapped_column(JSON)
+    lock_version: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
 
     tenant = relationship("Tenant", back_populates="transactions")
     shareholder = relationship("Shareholder", back_populates="transactions")
     plan = relationship("EmployeePlan", back_populates="transactions")
+
+    __mapper_args__ = {"version_id_col": lock_version}
 
 
 __all__ = ["Transaction", "TransactionType", "TransactionStatus"]

--- a/app/obs/__init__.py
+++ b/app/obs/__init__.py
@@ -1,0 +1,5 @@
+"""Observability utilities."""
+
+from .audit import AuditLogRecord, AuditMiddleware
+
+__all__ = ["AuditLogRecord", "AuditMiddleware"]

--- a/app/obs/audit.py
+++ b/app/obs/audit.py
@@ -1,0 +1,244 @@
+"""Audit logging middleware and utilities."""
+from __future__ import annotations
+
+import json
+import logging
+import random
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Callable
+from uuid import uuid4
+
+import boto3
+from botocore.exceptions import ClientError  # type: ignore[import-untyped]
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import Response
+from starlette.types import ASGIApp
+
+from app.core.config import Settings
+
+_SENSITIVE_KEYS = {
+    "email",
+    "phone",
+    "phone_number",
+    "account_number",
+    "routing_number",
+    "bank_account_number",
+    "tax_id",
+    "ssn",
+}
+
+
+def _mask_value(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: _mask_value(value[key]) for key in value}
+    if isinstance(value, list):
+        return [_mask_value(item) for item in value]
+    if isinstance(value, str):
+        if "@" in value:
+            name, _, domain = value.partition("@")
+            hidden = name[0] + "***" if name else "***"
+            return f"{hidden}@{domain}" if domain else "***@***"
+        if value.isdigit() and len(value) > 4:
+            return f"***{value[-4:]}"
+    return value
+
+
+def _mask_mapping(mapping: dict[str, Any]) -> dict[str, Any]:
+    sanitized: dict[str, Any] = {}
+    for key, value in mapping.items():
+        if key.lower() in _SENSITIVE_KEYS:
+            if isinstance(value, str) and len(value) > 4:
+                sanitized[key] = f"***{value[-4:]}"
+            else:
+                sanitized[key] = "***"
+        else:
+            sanitized[key] = _mask_value(value)
+    return sanitized
+
+
+@dataclass(slots=True)
+class AuditLogRecord:
+    """Structured log entry emitted by the middleware."""
+
+    timestamp: str
+    request_id: str
+    method: str
+    path: str
+    status: int
+    duration_ms: float
+    actor: str | None
+    tenant_id: str | None
+    ip_address: str | None
+    query: dict[str, Any]
+    body: Any
+
+    def to_json(self) -> str:
+        payload = {
+            "timestamp": self.timestamp,
+            "request_id": self.request_id,
+            "method": self.method,
+            "path": self.path,
+            "status": self.status,
+            "duration_ms": round(self.duration_ms, 2),
+            "actor": self.actor,
+            "tenant_id": self.tenant_id,
+            "ip_address": self.ip_address,
+            "query": self.query,
+            "body": self.body,
+        }
+        return json.dumps(payload, default=str)
+
+    def to_dict(self) -> dict[str, Any]:
+        return json.loads(self.to_json())
+
+
+class AuditMiddleware(BaseHTTPMiddleware):
+    """Starlette middleware capturing audit trails for compliance."""
+
+    def __init__(
+        self,
+        app: ASGIApp,
+        *,
+        settings: Settings,
+        logger: logging.Logger | None = None,
+        s3_client_factory: Callable[[], Any] | None = None,
+    ) -> None:
+        super().__init__(app)
+        self._settings = settings
+        self._logger = logger or logging.getLogger("audit")
+        self._s3_client_factory = s3_client_factory or self._default_client_factory
+        self._s3_client: Any | None = None
+        self._bucket_ready = False
+
+    async def dispatch(self, request: Request, call_next: Callable[[Request], Any]) -> Response:
+        request_id = request.headers.get("X-Request-ID") or uuid4().hex
+        request.state.request_id = request_id
+        start = time.perf_counter()
+
+        body_bytes = await request.body()
+        self._set_body(request, body_bytes)
+
+        masked_body = None
+        if body_bytes:
+            try:
+                parsed = json.loads(body_bytes)
+                masked_body = _mask_value(parsed)
+                if isinstance(parsed, dict):
+                    masked_body = _mask_mapping(masked_body)
+            except json.JSONDecodeError:
+                masked_body = "<binary>"
+
+        response = await call_next(request)
+
+        duration_ms = (time.perf_counter() - start) * 1000
+        actor = getattr(request.state, "actor_email", None)
+        tenant_id = getattr(request.state, "tenant_id", None)
+        ip_address = request.client.host if request.client else None
+        query_dict = _mask_mapping(dict(request.query_params.multi_items()))
+
+        record = AuditLogRecord(
+            timestamp=datetime.now(timezone.utc).isoformat(),
+            request_id=request_id,
+            method=request.method,
+            path=request.url.path,
+            status=response.status_code,
+            duration_ms=duration_ms,
+            actor=actor,
+            tenant_id=tenant_id,
+            ip_address=ip_address,
+            query=query_dict,
+            body=masked_body,
+        )
+
+        self._logger.info(record.to_json())
+        self._persist_to_s3(record)
+
+        response.headers["X-Request-ID"] = request_id
+        return response
+
+    def _default_client_factory(self) -> Any:
+        return boto3.client(
+            "s3",
+            region_name=self._settings.aws_region,
+            endpoint_url=self._settings.s3_endpoint_url,
+        )
+
+    def _get_s3_client(self) -> Any:
+        if self._s3_client is None:
+            self._s3_client = self._s3_client_factory()
+        return self._s3_client
+
+    def _ensure_bucket(self, client: Any) -> None:
+        if self._bucket_ready:
+            return
+        bucket = self._settings.audit_log_bucket
+        try:
+            client.head_bucket(Bucket=bucket)
+        except ClientError:
+            create_params = {"Bucket": bucket}
+            if self._settings.aws_region != "us-east-1" and self._settings.s3_endpoint_url is None:
+                create_params["CreateBucketConfiguration"] = {"LocationConstraint": self._settings.aws_region}
+            try:
+                client.create_bucket(**create_params)
+            except ClientError as exc:  # pragma: no cover - configuration issues
+                self._logger.error("failed to create audit bucket", extra={"error": str(exc)})
+                return
+        self._bucket_ready = True
+
+    def _persist_to_s3(self, record: AuditLogRecord) -> None:
+        if self._settings.audit_log_sample_rate <= 0:
+            return
+        if self._settings.audit_log_sample_rate < 1 and random.random() > self._settings.audit_log_sample_rate:
+            return
+
+        try:
+            client = self._get_s3_client()
+        except Exception as exc:  # pragma: no cover - defensive guard
+            self._logger.error("failed to obtain s3 client", extra={"error": str(exc)})
+            return
+
+        try:
+            self._ensure_bucket(client)
+            key = self._daily_key()
+            try:
+                existing = client.get_object(Bucket=self._settings.audit_log_bucket, Key=key)["Body"].read()
+            except client.exceptions.NoSuchKey:  # type: ignore[attr-defined]
+                existing = b""
+            except ClientError as exc:
+                error_code = exc.response.get("Error", {}).get("Code")
+                if error_code in {"404", "NoSuchKey"}:
+                    existing = b""
+                else:
+                    raise
+            payload = record.to_json().encode("utf-8") + b"\n"
+            client.put_object(
+                Bucket=self._settings.audit_log_bucket,
+                Key=key,
+                Body=existing + payload,
+                ContentType="application/json",
+            )
+        except Exception as exc:  # pragma: no cover - S3 connectivity issues
+            self._logger.error("failed to persist audit record", extra={"error": str(exc)})
+
+    def _daily_key(self) -> str:
+        now = datetime.now(timezone.utc)
+        prefix = self._settings.audit_log_prefix.rstrip("/")
+        return f"{prefix}/{now:%Y/%m/%d}/audit.log"
+
+    @staticmethod
+    def _set_body(request: Request, body: bytes) -> None:
+        async def receive() -> dict[str, Any]:
+            nonlocal consumed
+            if consumed:
+                return {"type": "http.request", "body": b"", "more_body": False}
+            consumed = True
+            return {"type": "http.request", "body": body, "more_body": False}
+
+        consumed = False
+        request._receive = receive  # type: ignore[attr-defined]
+
+
+__all__ = ["AuditLogRecord", "AuditMiddleware"]

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -9,6 +9,7 @@ from .plan import (
 )
 from .proxy import ProxyVoteCreate, ProxyVoteRead, ProxyVoteSummary
 from .shareholder import ShareholderCreate, ShareholderRead, ShareholderUpdate
+from .transaction import DisbursementRequest, DisbursementResponse
 
 __all__ = [
     "DividendEventPayload",
@@ -24,4 +25,6 @@ __all__ = [
     "ShareholderCreate",
     "ShareholderRead",
     "ShareholderUpdate",
+    "DisbursementRequest",
+    "DisbursementResponse",
 ]

--- a/app/schemas/transaction.py
+++ b/app/schemas/transaction.py
@@ -1,0 +1,33 @@
+"""Pydantic schemas for transaction resources."""
+from __future__ import annotations
+
+from decimal import Decimal
+
+from pydantic import BaseModel, Field
+
+from app.models import TransactionStatus
+
+
+class DisbursementRequest(BaseModel):
+    shareholder_id: str = Field(..., min_length=1, max_length=64)
+    amount: Decimal = Field(..., gt=0)
+    currency: str = Field(default="USD", min_length=3, max_length=3)
+    memo: str | None = Field(default=None, max_length=255)
+    bank_account_number: str = Field(..., min_length=4, max_length=34)
+    bank_routing_number: str = Field(..., min_length=4, max_length=9)
+
+
+class DisbursementResponse(BaseModel):
+    transaction_id: str
+    shareholder_id: str
+    amount: Decimal
+    currency: str
+    status: TransactionStatus
+    lock_version: int
+    request_id: str
+
+    class Config:
+        use_enum_values = True
+
+
+__all__ = ["DisbursementRequest", "DisbursementResponse"]

--- a/app/services/disbursements.py
+++ b/app/services/disbursements.py
@@ -1,0 +1,319 @@
+"""Disbursement orchestration services."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from decimal import Decimal
+from typing import Protocol
+
+import httpx
+from sqlalchemy.orm import Session
+from sqlalchemy.orm.exc import StaleDataError
+
+from app.core.config import Settings, get_settings
+from app.models import AuditLog, Shareholder, Transaction, TransactionStatus, TransactionType
+
+
+class DisbursementError(RuntimeError):
+    """Base class for disbursement service errors."""
+
+
+class ShareholderNotFoundError(DisbursementError):
+    """Raised when the shareholder cannot be located for the tenant."""
+
+
+class ShareholderKYCError(DisbursementError):
+    """Raised when the shareholder has not passed required KYC checks."""
+
+
+class DisbursementAdapterError(DisbursementError):
+    """Raised when the external ACH adapter call fails."""
+
+
+class DisbursementConcurrencyError(DisbursementError):
+    """Raised when optimistic locking detects a concurrent update."""
+
+
+@dataclass(slots=True, frozen=True)
+class DisbursementPayload:
+    """Input data for a disbursement request."""
+
+    shareholder_id: str
+    amount: Decimal
+    currency: str
+    memo: str | None
+    bank_account_number: str
+    bank_routing_number: str
+
+
+@dataclass(slots=True, frozen=True)
+class ACHDisbursementRequest:
+    """Payload submitted to the ACH adapter."""
+
+    tenant_id: str
+    shareholder_id: str
+    amount: Decimal
+    currency: str
+    account_number: str
+    routing_number: str
+    memo: str | None
+    request_id: str
+
+    def to_json(self) -> dict[str, str | float | None]:
+        return {
+            "tenant_id": self.tenant_id,
+            "shareholder_id": self.shareholder_id,
+            "amount": float(self.amount),
+            "currency": self.currency,
+            "account_number": self.account_number,
+            "routing_number": self.routing_number,
+            "memo": self.memo,
+            "request_id": self.request_id,
+        }
+
+    def masked(self) -> dict[str, str | None]:
+        account_last4 = self.account_number[-4:]
+        routing = self.routing_number
+        if len(routing) > 4:
+            routing = f"{routing[:3]}***{routing[-1]}"
+        else:
+            routing = "***"
+        return {
+            "tenant_id": self.tenant_id,
+            "shareholder_id": self.shareholder_id,
+            "amount": f"{self.amount:.2f}",
+            "currency": self.currency,
+            "account_last4": account_last4,
+            "routing": routing,
+            "memo": self.memo,
+            "request_id": self.request_id,
+        }
+
+
+@dataclass(slots=True, frozen=True)
+class ACHDisbursementResponse:
+    """Response returned from the ACH adapter."""
+
+    reference: str
+    status: str
+    message: str | None = None
+
+    @property
+    def accepted(self) -> bool:
+        value = self.status.upper()
+        return value in {"ACCEPTED", "SETTLED", "SUCCESS"}
+
+    def to_dict(self) -> dict[str, str | None]:
+        return {"reference": self.reference, "status": self.status, "message": self.message}
+
+
+class ACHAdapter(Protocol):
+    """Protocol describing an ACH disbursement adapter."""
+
+    def submit(self, *, transaction: Transaction, request: ACHDisbursementRequest) -> ACHDisbursementResponse:
+        """Submit the disbursement request and return the adapter response."""
+
+
+class HTTPACHAdapter:
+    """HTTP client used to interact with a mock ACH adapter."""
+
+    def __init__(self, *, endpoint: str, timeout_seconds: float) -> None:
+        self._endpoint = endpoint
+        self._timeout = timeout_seconds
+
+    def submit(self, *, transaction: Transaction, request: ACHDisbursementRequest) -> ACHDisbursementResponse:
+        try:
+            response = httpx.post(self._endpoint, json=request.to_json(), timeout=self._timeout)
+            response.raise_for_status()
+        except httpx.HTTPError as exc:  # pragma: no cover - network errors handled in tests via adapter error
+            raise DisbursementAdapterError("Failed to call ACH adapter") from exc
+
+        try:
+            payload = response.json()
+        except ValueError as exc:  # pragma: no cover - invalid adapter response
+            raise DisbursementAdapterError("Invalid ACH adapter response") from exc
+
+        reference = payload.get("reference")
+        status = payload.get("status")
+        message = payload.get("message")
+        if not reference or not status:
+            raise DisbursementAdapterError("Incomplete ACH adapter response")
+        return ACHDisbursementResponse(reference=str(reference), status=str(status), message=message)
+
+
+class DisbursementService:
+    """Coordinates disbursement transaction lifecycle."""
+
+    _ALLOWED_TRANSITIONS: dict[TransactionStatus, set[TransactionStatus]] = {
+        TransactionStatus.PENDING: {TransactionStatus.SENT},
+        TransactionStatus.SENT: {TransactionStatus.SETTLED, TransactionStatus.FAILED},
+    }
+
+    def __init__(
+        self,
+        session: Session,
+        *,
+        settings: Settings | None = None,
+        adapter: ACHAdapter | None = None,
+    ) -> None:
+        self._session = session
+        self._settings = settings or get_settings()
+        self._adapter = adapter or HTTPACHAdapter(
+            endpoint=self._settings.ach_adapter_url,
+            timeout_seconds=self._settings.ach_adapter_timeout_seconds,
+        )
+
+    def disburse(
+        self,
+        *,
+        tenant_id: str,
+        payload: DisbursementPayload,
+        actor_email: str,
+        request_id: str,
+    ) -> Transaction:
+        shareholder = self._session.get(Shareholder, payload.shareholder_id)
+        if shareholder is None or shareholder.tenant_id != tenant_id:
+            raise ShareholderNotFoundError(
+                f"Shareholder '{payload.shareholder_id}' was not found for tenant '{tenant_id}'"
+            )
+        if not shareholder.kyc_verified:
+            raise ShareholderKYCError("Shareholder has not completed KYC verification")
+
+        normalized_amount = payload.amount.quantize(Decimal("0.01"))
+        transaction = Transaction(
+            tenant_id=tenant_id,
+            shareholder_id=shareholder.id,
+            amount=normalized_amount,
+            currency=payload.currency,
+            type=TransactionType.DISBURSE,
+            status=TransactionStatus.PENDING,
+            details={
+                "memo": payload.memo,
+                "request_id": request_id,
+                "created_at": datetime.utcnow().isoformat(),
+            },
+        )
+        self._session.add(transaction)
+        self._session.flush()
+
+        adapter_request = ACHDisbursementRequest(
+            tenant_id=tenant_id,
+            shareholder_id=shareholder.id,
+            amount=normalized_amount,
+            currency=payload.currency,
+            account_number=payload.bank_account_number,
+            routing_number=payload.bank_routing_number,
+            memo=payload.memo,
+            request_id=request_id,
+        )
+
+        self._transition(transaction, TransactionStatus.SENT, extra_details={"ach_request": adapter_request.masked()})
+        self._session.commit()
+        self._session.refresh(transaction)
+
+        try:
+            adapter_response = self._adapter.submit(transaction=transaction, request=adapter_request)
+        except DisbursementAdapterError:
+            self._session.refresh(transaction)
+            self._transition(
+                transaction,
+                TransactionStatus.FAILED,
+                extra_details={"error": "ACH adapter call failed"},
+            )
+            self._record_audit(
+                transaction=transaction,
+                status=TransactionStatus.FAILED,
+                actor_email=actor_email,
+                request_id=request_id,
+                message="ACH adapter call failed",
+            )
+            self._session.commit()
+            self._session.refresh(transaction)
+            raise
+
+        final_status = TransactionStatus.SETTLED if adapter_response.accepted else TransactionStatus.FAILED
+        self._transition(
+            transaction,
+            final_status,
+            extra_details={"ach_response": adapter_response.to_dict()},
+        )
+
+        self._record_audit(
+            transaction=transaction,
+            status=final_status,
+            actor_email=actor_email,
+            request_id=request_id,
+            message=adapter_response.message,
+        )
+
+        self._session.commit()
+        self._session.refresh(transaction)
+        return transaction
+
+    def _transition(
+        self,
+        transaction: Transaction,
+        new_status: TransactionStatus,
+        *,
+        extra_details: dict | None = None,
+    ) -> None:
+        allowed = self._ALLOWED_TRANSITIONS.get(transaction.status, set())
+        if new_status not in allowed:
+            raise DisbursementError(
+                f"Invalid status transition from {transaction.status} to {new_status}"
+            )
+
+        merged_details = dict(transaction.details or {})
+        if extra_details:
+            merged_details.update(extra_details)
+
+        transaction.status = new_status
+        transaction.details = merged_details
+        try:
+            self._session.flush()
+        except StaleDataError as exc:
+            self._session.rollback()
+            raise DisbursementConcurrencyError("Transaction was modified concurrently") from exc
+
+    def _record_audit(
+        self,
+        *,
+        transaction: Transaction,
+        status: TransactionStatus,
+        actor_email: str,
+        request_id: str,
+        message: str | None,
+    ) -> None:
+        log = AuditLog(
+            tenant_id=transaction.tenant_id,
+            actor_id=None,
+            action="transaction.disburse",
+            resource_type="Transaction",
+            resource_id=transaction.id,
+            payload={
+                "status": status.value,
+                "amount": f"{Decimal(transaction.amount):.2f}",
+                "currency": transaction.currency,
+                "shareholder_id": transaction.shareholder_id,
+                "actor_email": actor_email,
+                "request_id": request_id,
+                "message": message,
+            },
+            ip_address=None,
+        )
+        self._session.add(log)
+
+
+__all__ = [
+    "ACHDisbursementRequest",
+    "ACHDisbursementResponse",
+    "ACHAdapter",
+    "DisbursementAdapterError",
+    "DisbursementConcurrencyError",
+    "DisbursementError",
+    "DisbursementPayload",
+    "DisbursementService",
+    "HTTPACHAdapter",
+    "ShareholderKYCError",
+    "ShareholderNotFoundError",
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
 from collections.abc import Iterator
+from io import BytesIO
 from pathlib import Path
 import sys
+from types import SimpleNamespace
 
 import pytest
+from botocore.exceptions import ClientError
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session, sessionmaker
@@ -16,7 +19,53 @@ if str(ROOT_DIR) not in sys.path:
 
 from app.api.deps import get_db_session
 from app.main import app
+from app.main import app as fastapi_app
 from app.models import Base, Tenant, TenantType
+from app.obs import AuditMiddleware
+
+
+class InMemoryS3Client:
+    """Simple in-memory S3 stub used by the audit middleware during tests."""
+
+    exceptions = SimpleNamespace(NoSuchKey=type("NoSuchKey", (Exception,), {}))
+
+    def __init__(self) -> None:
+        self._buckets: dict[str, dict[str, bytes]] = {}
+
+    def head_bucket(self, *, Bucket: str) -> None:
+        if Bucket not in self._buckets:
+            raise ClientError({"Error": {"Code": "404", "Message": "Not Found"}}, "HeadBucket")
+
+    def create_bucket(self, *, Bucket: str, **_: object) -> None:
+        self._buckets.setdefault(Bucket, {})
+
+    def get_object(self, *, Bucket: str, Key: str) -> dict[str, BytesIO]:
+        if Bucket not in self._buckets:
+            raise ClientError({"Error": {"Code": "NoSuchBucket"}}, "GetObject")
+        bucket = self._buckets[Bucket]
+        if Key not in bucket:
+            raise self.exceptions.NoSuchKey()
+        return {"Body": BytesIO(bucket[Key])}
+
+    def put_object(
+        self,
+        *,
+        Bucket: str,
+        Key: str,
+        Body: bytes,
+        ContentType: str | None = None,
+    ) -> dict[str, str]:
+        bucket = self._buckets.setdefault(Bucket, {})
+        if isinstance(Body, str):
+            data = Body.encode("utf-8")
+        else:
+            data = Body
+        bucket[Key] = data
+        return {"ETag": "in-memory"}
+
+    @property
+    def buckets(self) -> dict[str, dict[str, bytes]]:
+        return self._buckets
 
 
 DATABASE_URL = "sqlite+pysqlite:///./test_suite.db"
@@ -28,6 +77,24 @@ engine = create_engine(
     poolclass=StaticPool,
 )
 TestingSessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+
+
+@pytest.fixture(autouse=True)
+def audit_s3_client(monkeypatch: pytest.MonkeyPatch) -> Iterator[InMemoryS3Client]:
+    client = InMemoryS3Client()
+
+    def _client_factory(*args: object, **kwargs: object) -> InMemoryS3Client:
+        return client
+
+    monkeypatch.setattr("app.obs.audit.boto3.client", _client_factory)
+    stack = getattr(fastapi_app, "middleware_stack", None)
+    middleware = getattr(stack, "app", None)
+    while middleware is not None and hasattr(middleware, "app"):
+        if isinstance(middleware, AuditMiddleware):
+            middleware._s3_client = None
+            middleware._bucket_ready = False
+        middleware = getattr(middleware, "app", None)
+    yield client
 
 
 @pytest.fixture()
@@ -45,7 +112,7 @@ def db_session() -> Iterator[Session]:
 
 
 @pytest.fixture()
-def client(db_session: Session) -> Iterator[TestClient]:
+def client(db_session: Session, audit_s3_client: InMemoryS3Client) -> Iterator[TestClient]:
     def override_get_db() -> Iterator[Session]:
         try:
             yield db_session
@@ -61,7 +128,7 @@ def client(db_session: Session) -> Iterator[TestClient]:
 
 
 @pytest.fixture()
-def auth_headers(client: TestClient) -> dict[str, str]:
+def auth_headers(client: TestClient, audit_s3_client: InMemoryS3Client) -> dict[str, str]:
     response = client.post(
         "/api/auth/login",
         json={"email": "admin@example.com", "password": "changeme"},

--- a/tests/integration/test_disbursements.py
+++ b/tests/integration/test_disbursements.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+from decimal import Decimal
+import json
+from uuid import uuid4
+
+import pytest
+
+from app.core.config import get_settings
+from app.models import AuditLog, Shareholder, ShareholderType, Transaction, TransactionStatus
+from app.services.disbursements import (
+    ACHDisbursementResponse,
+    DisbursementConcurrencyError,
+    DisbursementPayload,
+    DisbursementService,
+)
+from tests.conftest import InMemoryS3Client, TestingSessionLocal
+
+
+class DummyResponse:
+    def __init__(self, payload: dict[str, str]) -> None:
+        self._payload = payload
+        self.status_code = 200
+
+    def raise_for_status(self) -> None:  # pragma: no cover - behaviour exercised implicitly
+        return None
+
+    def json(self) -> dict[str, str]:
+        return self._payload
+
+
+def test_disbursement_success_flow(
+    client,
+    db_session,
+    auth_headers,
+    audit_s3_client: InMemoryS3Client,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    shareholder = Shareholder(
+        tenant_id="tenant-demo",
+        external_ref="EXT-123",
+        full_name="Paula Payout",
+        email="paula@example.com",
+        type=ShareholderType.INDIVIDUAL,
+        total_shares=Decimal("100"),
+        kyc_verified=True,
+    )
+    db_session.add(shareholder)
+    db_session.commit()
+
+    payload = {
+        "shareholder_id": shareholder.id,
+        "amount": "250.75",
+        "currency": "USD",
+        "memo": "Quarterly bonus",
+        "bank_account_number": "123456789012",
+        "bank_routing_number": "111000025",
+    }
+
+    def fake_post(*args, **kwargs):
+        return DummyResponse({"reference": "ACH-123", "status": "ACCEPTED", "message": "queued"})
+
+    monkeypatch.setattr("app.services.disbursements.httpx.post", fake_post)
+
+    request_id = uuid4().hex
+    response = client.post(
+        "/api/transactions/disburse",
+        headers={**auth_headers, "X-Request-ID": request_id},
+        json=payload,
+    )
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["status"] == TransactionStatus.SETTLED.value
+    assert body["request_id"] == request_id
+
+    transaction = db_session.get(Transaction, body["transaction_id"])
+    assert transaction is not None
+    assert transaction.status == TransactionStatus.SETTLED
+    assert transaction.lock_version >= 2
+    assert transaction.details is not None
+    assert transaction.details["ach_request"]["account_last4"] == "9012"
+    assert transaction.details["ach_response"]["reference"] == "ACH-123"
+
+    audit_entry = db_session.query(AuditLog).first()
+    assert audit_entry is not None
+    assert audit_entry.payload["request_id"] == request_id
+    assert audit_entry.payload["status"] == TransactionStatus.SETTLED.value
+
+    settings = get_settings()
+    bucket_contents = audit_s3_client.buckets.get(settings.audit_log_bucket, {})
+    assert bucket_contents, "expected audit logs to be written to S3"
+    key, data = next(iter(bucket_contents.items()))
+    lines = [line for line in data.decode("utf-8").splitlines() if line]
+    assert lines, "expected audit logs to be written to S3"
+    last_entry = json.loads(lines[-1])
+    assert last_entry["request_id"] == request_id
+    assert last_entry["status"] == 201
+
+
+def test_disbursement_requires_kyc(
+    client,
+    db_session,
+    auth_headers,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    shareholder = Shareholder(
+        tenant_id="tenant-demo",
+        external_ref="EXT-999",
+        full_name="Kyc Pending",
+        email="pending@example.com",
+        type=ShareholderType.INDIVIDUAL,
+        total_shares=Decimal("10"),
+        kyc_verified=False,
+    )
+    db_session.add(shareholder)
+    db_session.commit()
+
+    response = client.post(
+        "/api/transactions/disburse",
+        headers=auth_headers,
+        json={
+            "shareholder_id": shareholder.id,
+            "amount": "20",
+            "currency": "USD",
+            "memo": "Incomplete",
+            "bank_account_number": "444455556666",
+            "bank_routing_number": "021000021",
+        },
+    )
+
+    assert response.status_code == 400
+    assert "KYC" in response.json()["detail"].upper()
+
+
+class RacingAdapter:
+    def submit(self, *, transaction: Transaction, request) -> ACHDisbursementResponse:
+        other_session = TestingSessionLocal()
+        try:
+            competing = other_session.get(Transaction, transaction.id)
+            assert competing is not None
+            competing.status = TransactionStatus.FAILED
+            competing.details = {"race": True}
+            other_session.commit()
+        finally:
+            other_session.close()
+        return ACHDisbursementResponse(reference="RACE", status="ACCEPTED", message="ok")
+
+
+def test_disbursement_detects_concurrent_updates(db_session) -> None:
+    shareholder = Shareholder(
+        tenant_id="tenant-demo",
+        external_ref="EXT-777",
+        full_name="Concurrent Actor",
+        email="actor@example.com",
+        type=ShareholderType.INDIVIDUAL,
+        total_shares=Decimal("25"),
+        kyc_verified=True,
+    )
+    db_session.add(shareholder)
+    db_session.commit()
+
+    service = DisbursementService(db_session, adapter=RacingAdapter())
+    payload = DisbursementPayload(
+        shareholder_id=shareholder.id,
+        amount=Decimal("100"),
+        currency="USD",
+        memo="",
+        bank_account_number="987654321000",
+        bank_routing_number="026009593",
+    )
+
+    with pytest.raises(DisbursementConcurrencyError):
+        service.disburse(
+            tenant_id="tenant-demo",
+            payload=payload,
+            actor_email="ops@example.com",
+            request_id="race",
+        )
+
+    db_session.rollback()
+    transaction = db_session.query(Transaction).order_by(Transaction.created_at.desc()).first()
+    assert transaction is not None
+    assert transaction.status == TransactionStatus.FAILED


### PR DESCRIPTION
## Summary
- add a disbursement service and FastAPI route that call a mock ACH adapter with optimistic locking
- introduce audit middleware that emits structured logs, masks PII, and writes JSONL records to S3
- extend schema/model layers for KYC and versioning plus integration tests covering success, failure, and concurrency

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dcc0d649f083288979c26f859146b4