### PR TITLE
Add observability instrumentation and deployment assets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,25 +7,51 @@ on:
     branches: [main]
 
 jobs:
-  build:
+  ci:
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v4
+
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
           python-version: "3.11"
+
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -e .[dev]
+
+      - name: Run pre-commit hooks
+        run: pre-commit run --all-files
+
       - name: Lint
         run: |
-          ruff check api
-          black --check api
-          isort --check-only api
+          ruff check app
+          black --check app
+          isort --check-only app
+
       - name: Type check
-        run: mypy api
-      - name: Tests
-        run: pytest
+        run: mypy app
+
+      - name: Unit tests with coverage
+        run: pytest tests/unit --cov=app --cov-report=xml --cov-report=term-missing --cov-fail-under=80
+
+      - name: Start integration stack
+        run: docker compose -f docker-compose.yml up -d --quiet-pull
+
+      - name: Integration tests
+        run: pytest tests/integration -q
+
+      - name: Tear down stack
+        if: always()
+        run: docker compose -f docker-compose.yml down --remove-orphans
+
+      - name: Build container image
+        run: docker build -t fintech-platform:ci .
+
+      - name: Helm dry run
+        run: helm template fintech infra/helm/fintech

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -40,6 +40,15 @@ class Settings(BaseSettings):
     )
     upload_validator_poll_interval_seconds: int = Field(default=2)
 
+    enable_metrics: bool = Field(default=True)
+    enable_tracing: bool = Field(default=True)
+    otel_exporter_endpoint: str | None = Field(default=None)
+
+    audit_log_retention_days: int = Field(default=365)
+    transaction_retention_days: int = Field(default=365)
+    upload_retention_days: int = Field(default=180)
+    data_retention_interval_seconds: int = Field(default=3600)
+
     kafka_bootstrap_servers: str = Field(default="kafka:9092")
     transaction_events_topic: str = Field(default="transaction-events")
     transaction_consumer_group: str = Field(default="transaction-reporting-service")

--- a/app/db/session.py
+++ b/app/db/session.py
@@ -7,9 +7,12 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import Session, sessionmaker
 
 from app.core.config import get_settings
+from app.obs import instrument_sqlalchemy_engine
 
 settings = get_settings()
 engine = create_engine(settings.database_url, pool_pre_ping=True)
+if settings.enable_tracing:
+    instrument_sqlalchemy_engine(engine)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -6,13 +6,22 @@ from fastapi import FastAPI
 from app.api.routes import register_routes
 from app.core.config import Settings, get_settings
 from app.core.logging import configure_logging
-from app.obs import AuditMiddleware
+from app.obs import (
+    AuditMiddleware,
+    PrometheusMiddleware,
+    initialise_tracing,
+    instrument_fastapi_app,
+    metrics_router,
+)
 
 
 def create_application(settings: Settings | None = None) -> FastAPI:
     """Application factory used by ASGI servers and tests."""
     configure_logging()
     settings = settings or get_settings()
+
+    if settings.enable_tracing:
+        initialise_tracing(service_name=settings.app_name, endpoint=settings.otel_exporter_endpoint)
 
     application = FastAPI(
         title=settings.app_name,
@@ -23,7 +32,13 @@ def create_application(settings: Settings | None = None) -> FastAPI:
     )
 
     application.add_middleware(AuditMiddleware, settings=settings)
+    if settings.enable_metrics:
+        application.add_middleware(PrometheusMiddleware)
+        application.include_router(metrics_router)
     register_routes(application)
+
+    if settings.enable_tracing:
+        instrument_fastapi_app(application)
 
     return application
 

--- a/app/obs/__init__.py
+++ b/app/obs/__init__.py
@@ -1,5 +1,40 @@
 """Observability utilities."""
 
 from .audit import AuditLogRecord, AuditMiddleware
+from .metrics import (
+    DATA_RETENTION_AUDIT_COUNTER,
+    DATA_RETENTION_TRANSACTION_COUNTER,
+    QUEUE_DEPTH_GAUGE,
+    REQUEST_COUNTER,
+    REQUEST_ERROR_COUNTER,
+    REQUEST_LATENCY_SECONDS,
+    PrometheusMiddleware,
+    metrics_router,
+    report_queue_depth,
+)
+from .tracing import (
+    initialise_tracing,
+    inject_traceparent,
+    instrument_fastapi_app,
+    instrument_sqlalchemy_engine,
+    span_from_traceparent,
+)
 
-__all__ = ["AuditLogRecord", "AuditMiddleware"]
+__all__ = [
+    "AuditLogRecord",
+    "AuditMiddleware",
+    "DATA_RETENTION_AUDIT_COUNTER",
+    "DATA_RETENTION_TRANSACTION_COUNTER",
+    "PrometheusMiddleware",
+    "QUEUE_DEPTH_GAUGE",
+    "REQUEST_COUNTER",
+    "REQUEST_ERROR_COUNTER",
+    "REQUEST_LATENCY_SECONDS",
+    "metrics_router",
+    "report_queue_depth",
+    "initialise_tracing",
+    "inject_traceparent",
+    "instrument_fastapi_app",
+    "instrument_sqlalchemy_engine",
+    "span_from_traceparent",
+]

--- a/app/obs/metrics.py
+++ b/app/obs/metrics.py
@@ -1,0 +1,94 @@
+"""Prometheus metrics utilities for API and worker processes."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Awaitable, Callable
+
+from fastapi import APIRouter, Request, Response
+from prometheus_client import CONTENT_TYPE_LATEST, Counter, Gauge, Histogram, generate_latest
+from starlette.middleware.base import BaseHTTPMiddleware
+
+REQUEST_LATENCY_SECONDS = Histogram(
+    "http_request_latency_seconds",
+    "Latency of HTTP requests in seconds.",
+    labelnames=("method", "path"),
+)
+REQUEST_COUNTER = Counter(
+    "http_requests_total",
+    "Total number of HTTP requests processed.",
+    labelnames=("method", "path", "status"),
+)
+REQUEST_ERROR_COUNTER = Counter(
+    "http_request_errors_total",
+    "Total number of HTTP requests that resulted in server errors.",
+    labelnames=("method", "path", "status"),
+)
+QUEUE_DEPTH_GAUGE = Gauge(
+    "worker_queue_depth",
+    "Depth of asynchronous worker queues awaiting processing.",
+    labelnames=("queue_name",),
+)
+DATA_RETENTION_AUDIT_COUNTER = Counter(
+    "data_retention_audit_logs_deleted_total",
+    "Count of audit log records deleted by the retention job.",
+)
+DATA_RETENTION_TRANSACTION_COUNTER = Counter(
+    "data_retention_transactions_deleted_total",
+    "Count of transaction records deleted by the retention job.",
+)
+
+
+class PrometheusMiddleware(BaseHTTPMiddleware):
+    """Middleware that records request metrics for Prometheus scraping."""
+
+    async def dispatch(
+        self, request: Request, call_next: Callable[[Request], Awaitable[Response]]
+    ) -> Response:  # type: ignore[override]
+        method = request.method
+        path = request.url.path
+        start_time = time.perf_counter()
+        status = "500"
+
+        try:
+            response = await call_next(request)
+            status = str(response.status_code)
+            if response.status_code >= 500:
+                REQUEST_ERROR_COUNTER.labels(method=method, path=path, status=status).inc()
+            return response
+        except Exception:
+            REQUEST_ERROR_COUNTER.labels(method=method, path=path, status="500").inc()
+            raise
+        finally:
+            latency = time.perf_counter() - start_time
+            REQUEST_LATENCY_SECONDS.labels(method=method, path=path).observe(latency)
+            REQUEST_COUNTER.labels(method=method, path=path, status=status).inc()
+
+
+metrics_router = APIRouter(tags=["observability"])
+
+
+@metrics_router.get("/metrics", include_in_schema=False)
+def metrics_endpoint() -> Response:
+    """Expose Prometheus metrics for scraping."""
+    payload = generate_latest()
+    return Response(content=payload, media_type=CONTENT_TYPE_LATEST)
+
+
+def report_queue_depth(queue_name: str, depth: int | float) -> None:
+    """Report the depth of a named worker queue."""
+    QUEUE_DEPTH_GAUGE.labels(queue_name=queue_name).set(max(0.0, float(depth)))
+
+
+__all__ = [
+    "PrometheusMiddleware",
+    "DATA_RETENTION_AUDIT_COUNTER",
+    "DATA_RETENTION_TRANSACTION_COUNTER",
+    "QUEUE_DEPTH_GAUGE",
+    "REQUEST_COUNTER",
+    "REQUEST_ERROR_COUNTER",
+    "REQUEST_LATENCY_SECONDS",
+    "metrics_endpoint",
+    "metrics_router",
+    "report_queue_depth",
+]

--- a/app/obs/tracing.py
+++ b/app/obs/tracing.py
@@ -1,0 +1,107 @@
+"""OpenTelemetry tracing helpers for API and worker services."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Any, Iterator
+
+from fastapi import FastAPI
+from opentelemetry import trace
+from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+from opentelemetry.instrumentation.logging import LoggingInstrumentor
+from opentelemetry.instrumentation.sqlalchemy import SQLAlchemyInstrumentor
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import (
+    BatchSpanProcessor,
+    ConsoleSpanExporter,
+    SimpleSpanProcessor,
+)
+from opentelemetry.trace import Span
+from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
+
+try:  # pragma: no cover - exporter may not be available in minimal environments
+    from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+except ModuleNotFoundError:  # pragma: no cover - graceful fallback for missing extras
+    OTLPSpanExporter = None  # type: ignore[assignment]
+
+_SERVICE_NAME_ATTRIBUTE = "service.name"
+
+
+def _create_tracer_provider(service_name: str, endpoint: str | None) -> TracerProvider:
+    resource = Resource(attributes={_SERVICE_NAME_ATTRIBUTE: service_name})
+    provider = TracerProvider(resource=resource)
+
+    exporter = None
+    if endpoint and OTLPSpanExporter is not None:
+        exporter = OTLPSpanExporter(endpoint=endpoint, insecure=True)
+    if exporter is not None:
+        processor = BatchSpanProcessor(exporter)
+    else:
+        processor = SimpleSpanProcessor(ConsoleSpanExporter())
+    provider.add_span_processor(processor)
+    return provider
+
+
+def initialise_tracing(
+    *,
+    service_name: str,
+    endpoint: str | None = None,
+    instrument_logging: bool = True,
+) -> None:
+    """Initialise a global tracer provider if one has not already been configured."""
+
+    current_provider = trace.get_tracer_provider()
+    if (
+        isinstance(current_provider, TracerProvider)
+        and getattr(current_provider.resource, "attributes", {}).get(_SERVICE_NAME_ATTRIBUTE)
+        == service_name
+    ):
+        return
+
+    provider = _create_tracer_provider(service_name, endpoint)
+    trace.set_tracer_provider(provider)
+    if instrument_logging:
+        LoggingInstrumentor().instrument(set_logging_format=True)
+
+
+def instrument_fastapi_app(app: FastAPI) -> None:
+    """Enable FastAPI OpenTelemetry instrumentation."""
+    FastAPIInstrumentor().instrument_app(app)
+
+
+def instrument_sqlalchemy_engine(engine: Any) -> None:
+    """Instrument SQLAlchemy engine for tracing if not already instrumented."""
+    SQLAlchemyInstrumentor().instrument(engine=engine)
+
+
+@contextmanager
+def span_from_traceparent(name: str, traceparent: str | None, **attributes: Any) -> Iterator[Span]:
+    """Create a span using an incoming ``traceparent`` header if provided."""
+
+    tracer = trace.get_tracer(__name__)
+    context = None
+    if traceparent:
+        carrier = {"traceparent": traceparent}
+        context = TraceContextTextMapPropagator().extract(carrier=carrier)
+    with tracer.start_as_current_span(name, context=context) as span:
+        for key, value in attributes.items():
+            span.set_attribute(key, value)
+        yield span
+
+
+def inject_traceparent(headers: dict[str, str]) -> dict[str, str]:
+    """Inject the current trace context into a carrier compatible with messaging systems."""
+
+    carrier: dict[str, str] = dict(headers)
+    TraceContextTextMapPropagator().inject(carrier)
+    return carrier
+
+
+__all__ = [
+    "initialise_tracing",
+    "instrument_fastapi_app",
+    "instrument_sqlalchemy_engine",
+    "inject_traceparent",
+    "span_from_traceparent",
+]

--- a/app/services/data_retention.py
+++ b/app/services/data_retention.py
@@ -1,0 +1,78 @@
+"""Data retention utilities for compliance and privacy."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import delete
+from sqlalchemy.orm import Session
+
+from app.core.config import Settings, get_settings
+from app.models import AuditLog, Transaction
+
+
+@dataclass(slots=True)
+class DataRetentionReport:
+    """Summary of a retention cycle."""
+
+    audit_logs_deleted: int
+    transactions_deleted: int
+
+    def total_deleted(self) -> int:
+        return self.audit_logs_deleted + self.transactions_deleted
+
+
+class DataRetentionService:
+    """Encapsulates data retention policies for databases and object storage."""
+
+    def __init__(self, session: Session, *, settings: Settings | None = None) -> None:
+        self._session = session
+        self._settings = settings or get_settings()
+
+    def purge_expired_records(self, *, now: datetime | None = None) -> DataRetentionReport:
+        """Purge records that exceed configured retention windows."""
+
+        current_time = now or datetime.now(timezone.utc)
+        audit_cutoff = current_time - timedelta(days=self._settings.audit_log_retention_days)
+        transaction_cutoff = current_time - timedelta(
+            days=self._settings.transaction_retention_days
+        )
+
+        audit_result = self._session.execute(
+            delete(AuditLog).where(AuditLog.created_at < audit_cutoff)
+        )
+        transaction_result = self._session.execute(
+            delete(Transaction).where(Transaction.created_at < transaction_cutoff)
+        )
+
+        deleted_audit = int(audit_result.rowcount or 0)
+        deleted_transactions = int(transaction_result.rowcount or 0)
+
+        return DataRetentionReport(
+            audit_logs_deleted=deleted_audit,
+            transactions_deleted=deleted_transactions,
+        )
+
+    def build_s3_lifecycle_policy(self) -> dict[str, object]:
+        """Return a placeholder S3 lifecycle configuration for IaC pipelines."""
+
+        return {
+            "Rules": [
+                {
+                    "ID": "expire-audit-logs",
+                    "Filter": {"Prefix": "audit/"},
+                    "Status": "Enabled",
+                    "Expiration": {"Days": self._settings.upload_retention_days},
+                },
+                {
+                    "ID": "expire-shareholder-uploads",
+                    "Filter": {"Prefix": self._settings.upload_prefix},
+                    "Status": "Enabled",
+                    "Expiration": {"Days": self._settings.upload_retention_days},
+                },
+            ]
+        }
+
+
+__all__ = ["DataRetentionReport", "DataRetentionService"]

--- a/app/workers/observability.py
+++ b/app/workers/observability.py
@@ -1,0 +1,51 @@
+"""Shared observability helpers for worker processes."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Any, Iterator, Sequence
+
+from opentelemetry import trace
+from opentelemetry.trace import Span
+
+from app.core.config import get_settings
+from app.obs import initialise_tracing, report_queue_depth, span_from_traceparent
+
+
+def configure_worker(service_name: str, *, queues: Sequence[str] | None = None) -> None:
+    """Initialise tracing and register queue metrics for a worker service."""
+
+    settings = get_settings()
+    if settings.enable_tracing:
+        initialise_tracing(
+            service_name=service_name,
+            endpoint=settings.otel_exporter_endpoint,
+            instrument_logging=False,
+        )
+    if settings.enable_metrics and queues:
+        for queue in queues:
+            report_queue_depth(queue, 0)
+
+
+@contextmanager
+def worker_span(name: str, traceparent: str | None = None, **attributes: Any) -> Iterator[Span]:
+    """Context manager that starts a worker span and attaches optional attributes."""
+
+    with span_from_traceparent(name, traceparent, **attributes) as span:
+        yield span
+
+
+def current_traceparent() -> str | None:
+    """Return a ``traceparent`` string for propagation to downstream systems."""
+
+    span = trace.get_current_span()
+    if span is None or span.get_span_context().trace_id == 0:
+        return None
+    carrier: dict[str, str] = {}
+    from app.obs import inject_traceparent  # Local import to avoid circular deps
+
+    populated = inject_traceparent(carrier)
+    return populated.get("traceparent")
+
+
+__all__ = ["configure_worker", "worker_span", "current_traceparent"]

--- a/docs/adr/0001-observability-stack.md
+++ b/docs/adr/0001-observability-stack.md
@@ -1,0 +1,18 @@
+# ADR 0001: Observability Stack Standardisation
+
+## Status
+Accepted
+
+## Context
+The platform must provide latency, rate, error, and backlog visibility across API and worker processes while satisfying compliance audit requirements. The codebase previously lacked consistent metrics and trace propagation.
+
+## Decision
+- Adopt Prometheus metrics via `PrometheusMiddleware` for API request instrumentation and worker queue depth gauges.
+- Use OpenTelemetry SDK with OTLP exporter for traces. FastAPI, SQLAlchemy, and workers are instrumented to propagate `traceparent` headers.
+- Emit data retention counters to track compliance deletes and expose `/metrics` for scraping.
+- Provide Grafana dashboards and runbooks checked into `docs/` for reproducible operations.
+
+## Consequences
+- Services require the OTLP collector endpoint to be configured in production environments.
+- Workers must import `app.workers.observability` to report queue depth and tracing context.
+- Prometheus client registry is shared across API and worker processes; processes must run with unique metric namespaces when using multiprocess setups.

--- a/docs/adr/0002-ci-cd-pipeline.md
+++ b/docs/adr/0002-ci-cd-pipeline.md
@@ -1,0 +1,22 @@
+# ADR 0002: CI/CD Pipeline Strategy
+
+## Status
+Accepted
+
+## Context
+To support continuous delivery and quality gates, the project requires a deterministic pipeline covering linting, typing, testing, container builds, and release validation. The previous CI workflow only executed basic linting and pytest runs.
+
+## Decision
+- Consolidate CI into a GitHub Actions workflow that:
+  - installs dependencies once,
+  - runs Ruff/Black/Isort linting and MyPy type checks,
+  - executes unit tests with coverage and integration tests after a `docker compose up`,
+  - builds the production container image, and
+  - performs a Helm `template --dry-run` validation using the repository chart.
+- Enforce `pytest --cov=app --cov-report=term-missing` with a minimum 80% threshold.
+- Provide Helm and Terraform stubs in `infra/` with documentation to unblock platform automation.
+
+## Consequences
+- CI runtime increases slightly due to container builds and Helm checks but provides higher confidence.
+- Local developers can mirror CI by invoking the documented Makefile commands.
+- Helm chart and Terraform modules must remain syntactically valid to keep CI green.

--- a/docs/dashboards/data-retention-dashboard.json
+++ b/docs/dashboards/data-retention-dashboard.json
@@ -1,0 +1,32 @@
+{
+  "title": "Data Retention Overview",
+  "panels": [
+    {
+      "type": "stat",
+      "title": "Audit Logs Deleted",
+      "targets": [
+        {
+          "expr": "sum(increase(data_retention_audit_logs_deleted_total[1h]))"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Transactions Deleted",
+      "targets": [
+        {
+          "expr": "sum(increase(data_retention_transactions_deleted_total[1h]))"
+        }
+      ]
+    },
+    {
+      "type": "graph",
+      "title": "Retention Job Duration",
+      "targets": [
+        {
+          "expr": "rate(http_request_latency_seconds_sum{path='/metrics'}[5m])"
+        }
+      ]
+    }
+  ]
+}

--- a/docs/dashboards/observability-dashboard.json
+++ b/docs/dashboards/observability-dashboard.json
@@ -1,0 +1,44 @@
+{
+  "title": "Fintech Platform Observability",
+  "panels": [
+    {
+      "type": "graph",
+      "title": "HTTP Request Latency",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(http_request_latency_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p95 latency"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Request Error Rate",
+      "targets": [
+        {
+          "expr": "sum(rate(http_request_errors_total[5m]))"
+        }
+      ],
+      "thresholds": "0.1,1"
+    },
+    {
+      "type": "table",
+      "title": "Worker Queue Depth",
+      "targets": [
+        {
+          "expr": "worker_queue_depth"
+        }
+      ]
+    }
+  ],
+  "templating": {
+    "list": [
+      {
+        "name": "service",
+        "type": "query",
+        "datasource": "Prometheus",
+        "definition": "label_values(http_requests_total, path)"
+      }
+    ]
+  }
+}

--- a/docs/diagrams/observability.md
+++ b/docs/diagrams/observability.md
@@ -1,0 +1,27 @@
+# Observability Data Flow
+
+```mermaid
+graph LR
+    subgraph API
+        A[FastAPI Middleware]
+        B[Prometheus Metrics]
+        C[OTel Tracer]
+    end
+    subgraph Workers
+        D[Upload Validator]
+        E[Transaction Reporter]
+        F[Data Retention]
+    end
+    A -->|traceparent| D
+    A -->|traceparent| E
+    A -->|traceparent| F
+    D -->|Queue Depth Gauge| G[(Prometheus)]
+    E -->|Queue Depth Gauge| G
+    F -->|Deletion Counters| G
+    C --> H[(OTLP Collector)]
+    D --> H
+    E --> H
+    F --> H
+    G --> I[Grafana]
+    H --> J[Tracing Backend]
+```

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1,0 +1,1588 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Fintech Platform",
+    "version": "0.1.0"
+  },
+  "paths": {
+    "/api/healthz": {
+      "get": {
+        "tags": [
+          "health"
+        ],
+        "summary": "Liveness check",
+        "operationId": "health_check_api_healthz_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object",
+                  "title": "Response Health Check Api Healthz Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/readyz": {
+      "get": {
+        "tags": [
+          "health"
+        ],
+        "summary": "Readiness check",
+        "operationId": "readiness_check_api_readyz_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object",
+                  "title": "Response Readiness Check Api Readyz Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/auth/login": {
+      "post": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Issue JWT access tokens",
+        "operationId": "login_api_auth_login_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LoginRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TokenResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/auth/refresh": {
+      "post": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Rotate JWT refresh tokens",
+        "operationId": "refresh_token_api_auth_refresh_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RefreshRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TokenResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/auth/admin-area": {
+      "get": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Protected resource accessible to admins only",
+        "operationId": "admin_area_api_auth_admin_area_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object",
+                  "title": "Response Admin Area Api Auth Admin Area Get"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ]
+      }
+    },
+    "/api/auth/employee-area": {
+      "get": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Protected resource accessible to employees and admins",
+        "operationId": "employee_area_api_auth_employee_area_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object",
+                  "title": "Response Employee Area Api Auth Employee Area Get"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ]
+      }
+    },
+    "/api/plans/enroll": {
+      "post": {
+        "tags": [
+          "plans"
+        ],
+        "summary": "Enroll Plan",
+        "description": "Enroll an employee in a plan for the authenticated tenant.",
+        "operationId": "enroll_plan_api_plans_enroll_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlanEnrollmentRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlanRead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ]
+      }
+    },
+    "/api/plans/{plan_id}/contributions": {
+      "post": {
+        "tags": [
+          "plans"
+        ],
+        "summary": "Record Contribution",
+        "description": "Record a plan contribution and return the updated totals.",
+        "operationId": "record_contribution_api_plans__plan_id__contributions_post",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "plan_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Plan Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlanContributionRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlanContributionResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/shareholders/": {
+      "get": {
+        "tags": [
+          "shareholders"
+        ],
+        "summary": "List Shareholders",
+        "operationId": "list_shareholders_api_shareholders__get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/ShareholderRead"
+                  },
+                  "type": "array",
+                  "title": "Response List Shareholders Api Shareholders  Get"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "shareholders"
+        ],
+        "summary": "Create Shareholder",
+        "operationId": "create_shareholder_api_shareholders__post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ShareholderCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ShareholderRead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ]
+      }
+    },
+    "/api/shareholders/{shareholder_id}": {
+      "get": {
+        "tags": [
+          "shareholders"
+        ],
+        "summary": "Get Shareholder",
+        "operationId": "get_shareholder_api_shareholders__shareholder_id__get",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "shareholder_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Shareholder Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ShareholderRead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "shareholders"
+        ],
+        "summary": "Update Shareholder",
+        "operationId": "update_shareholder_api_shareholders__shareholder_id__put",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "shareholder_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Shareholder Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ShareholderUpdate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ShareholderRead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "shareholders"
+        ],
+        "summary": "Delete Shareholder",
+        "operationId": "delete_shareholder_api_shareholders__shareholder_id__delete",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "shareholder_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Shareholder Id"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/dividends/schedule": {
+      "post": {
+        "tags": [
+          "dividends"
+        ],
+        "summary": "Schedule Dividends",
+        "operationId": "schedule_dividends_api_dividends_schedule_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DividendScheduleRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DividendScheduleResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ]
+      }
+    },
+    "/api/proxy/votes": {
+      "post": {
+        "tags": [
+          "proxy"
+        ],
+        "summary": "Submit Proxy Vote",
+        "operationId": "submit_proxy_vote_api_proxy_votes_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProxyVoteCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProxyVoteRead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ]
+      }
+    },
+    "/api/proxy/votes/summary": {
+      "get": {
+        "tags": [
+          "proxy"
+        ],
+        "summary": "Proxy Vote Summary",
+        "operationId": "proxy_vote_summary_api_proxy_votes_summary_get",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "meeting_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "maxLength": 64,
+              "title": "Meeting Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProxyVoteSummary"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/transactions/disburse": {
+      "post": {
+        "tags": [
+          "transactions"
+        ],
+        "summary": "Create Disbursement",
+        "operationId": "create_disbursement_api_transactions_disburse_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DisbursementRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DisbursementResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ]
+      }
+    },
+    "/api/uploads/shareholders": {
+      "post": {
+        "tags": [
+          "uploads"
+        ],
+        "summary": "Upload Shareholders",
+        "operationId": "upload_shareholders_api_uploads_shareholders_post",
+        "responses": {
+          "202": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object",
+                  "title": "Response Upload Shareholders Api Uploads Shareholders Post"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ]
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "DisbursementRequest": {
+        "properties": {
+          "shareholder_id": {
+            "type": "string",
+            "maxLength": 64,
+            "minLength": 1,
+            "title": "Shareholder Id"
+          },
+          "amount": {
+            "anyOf": [
+              {
+                "type": "number",
+                "exclusiveMinimum": 0.0
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "title": "Amount"
+          },
+          "currency": {
+            "type": "string",
+            "maxLength": 3,
+            "minLength": 3,
+            "title": "Currency",
+            "default": "USD"
+          },
+          "memo": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 255
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Memo"
+          },
+          "bank_account_number": {
+            "type": "string",
+            "maxLength": 34,
+            "minLength": 4,
+            "title": "Bank Account Number"
+          },
+          "bank_routing_number": {
+            "type": "string",
+            "maxLength": 9,
+            "minLength": 4,
+            "title": "Bank Routing Number"
+          }
+        },
+        "type": "object",
+        "required": [
+          "shareholder_id",
+          "amount",
+          "bank_account_number",
+          "bank_routing_number"
+        ],
+        "title": "DisbursementRequest"
+      },
+      "DisbursementResponse": {
+        "properties": {
+          "transaction_id": {
+            "type": "string",
+            "title": "Transaction Id"
+          },
+          "shareholder_id": {
+            "type": "string",
+            "title": "Shareholder Id"
+          },
+          "amount": {
+            "type": "string",
+            "title": "Amount"
+          },
+          "currency": {
+            "type": "string",
+            "title": "Currency"
+          },
+          "status": {
+            "$ref": "#/components/schemas/TransactionStatus"
+          },
+          "lock_version": {
+            "type": "integer",
+            "title": "Lock Version"
+          },
+          "request_id": {
+            "type": "string",
+            "title": "Request Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "transaction_id",
+          "shareholder_id",
+          "amount",
+          "currency",
+          "status",
+          "lock_version",
+          "request_id"
+        ],
+        "title": "DisbursementResponse"
+      },
+      "DividendScheduleRequest": {
+        "properties": {
+          "dividend_rate": {
+            "anyOf": [
+              {
+                "type": "number",
+                "exclusiveMinimum": 0.0
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "title": "Dividend Rate"
+          },
+          "record_date": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Record Date"
+          },
+          "memo": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 255
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Memo"
+          }
+        },
+        "type": "object",
+        "required": [
+          "dividend_rate"
+        ],
+        "title": "DividendScheduleRequest"
+      },
+      "DividendScheduleResponse": {
+        "properties": {
+          "scheduled_events": {
+            "type": "integer",
+            "title": "Scheduled Events"
+          }
+        },
+        "type": "object",
+        "required": [
+          "scheduled_events"
+        ],
+        "title": "DividendScheduleResponse"
+      },
+      "EmployeePlanStatus": {
+        "type": "string",
+        "enum": [
+          "ACTIVE",
+          "SUSPENDED",
+          "CLOSED"
+        ],
+        "title": "EmployeePlanStatus"
+      },
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "type": "array",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "title": "HTTPValidationError"
+      },
+      "LoginRequest": {
+        "properties": {
+          "email": {
+            "type": "string",
+            "title": "Email"
+          },
+          "password": {
+            "type": "string",
+            "title": "Password"
+          },
+          "role": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "ADMIN",
+                  "EMPLOYEE",
+                  "COMPLIANCE",
+                  "OPS"
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Role"
+          }
+        },
+        "type": "object",
+        "required": [
+          "email",
+          "password"
+        ],
+        "title": "LoginRequest"
+      },
+      "PlanContributionRequest": {
+        "properties": {
+          "amount": {
+            "anyOf": [
+              {
+                "type": "number",
+                "exclusiveMinimum": 0.0
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "title": "Amount",
+            "description": "Contribution amount in plan currency"
+          },
+          "currency": {
+            "type": "string",
+            "maxLength": 3,
+            "minLength": 3,
+            "title": "Currency",
+            "default": "USD"
+          },
+          "reference": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 128
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reference"
+          }
+        },
+        "type": "object",
+        "required": [
+          "amount"
+        ],
+        "title": "PlanContributionRequest",
+        "description": "Contribution payload for an enrolled plan."
+      },
+      "PlanContributionResponse": {
+        "properties": {
+          "plan": {
+            "$ref": "#/components/schemas/PlanRead"
+          },
+          "transaction_id": {
+            "type": "string",
+            "title": "Transaction Id"
+          },
+          "amount": {
+            "type": "string",
+            "title": "Amount"
+          },
+          "currency": {
+            "type": "string",
+            "title": "Currency"
+          }
+        },
+        "type": "object",
+        "required": [
+          "plan",
+          "transaction_id",
+          "amount",
+          "currency"
+        ],
+        "title": "PlanContributionResponse",
+        "description": "Response returned after recording a contribution."
+      },
+      "PlanEnrollmentRequest": {
+        "properties": {
+          "shareholder_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Shareholder Id",
+            "description": "Existing shareholder identifier"
+          },
+          "employee_id": {
+            "type": "string",
+            "maxLength": 128,
+            "title": "Employee Id",
+            "description": "External employee identifier"
+          },
+          "plan_type": {
+            "$ref": "#/components/schemas/PlanType",
+            "description": "Plan type to enroll the employee in"
+          },
+          "vesting_schedule": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vesting Schedule",
+            "description": "Opaque vesting schedule definition stored on the plan record"
+          }
+        },
+        "type": "object",
+        "required": [
+          "employee_id",
+          "plan_type"
+        ],
+        "title": "PlanEnrollmentRequest",
+        "description": "Payload for enrolling an employee into a plan."
+      },
+      "PlanRead": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "tenant_id": {
+            "type": "string",
+            "title": "Tenant Id"
+          },
+          "shareholder_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Shareholder Id"
+          },
+          "employee_id": {
+            "type": "string",
+            "title": "Employee Id"
+          },
+          "plan_type": {
+            "$ref": "#/components/schemas/PlanType"
+          },
+          "status": {
+            "$ref": "#/components/schemas/EmployeePlanStatus"
+          },
+          "contribution_total": {
+            "type": "string",
+            "title": "Contribution Total"
+          },
+          "vesting_schedule": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vesting Schedule"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "tenant_id",
+          "shareholder_id",
+          "employee_id",
+          "plan_type",
+          "status",
+          "contribution_total",
+          "vesting_schedule"
+        ],
+        "title": "PlanRead",
+        "description": "Serialized representation of an enrolled employee plan."
+      },
+      "PlanType": {
+        "type": "string",
+        "enum": [
+          "ESPP",
+          "RSU",
+          "401K",
+          "PENSION"
+        ],
+        "title": "PlanType"
+      },
+      "ProxyVoteCreate": {
+        "properties": {
+          "meeting_id": {
+            "type": "string",
+            "maxLength": 64,
+            "title": "Meeting Id"
+          },
+          "shareholder_id": {
+            "type": "string",
+            "maxLength": 36,
+            "title": "Shareholder Id"
+          },
+          "ballot_choices": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object",
+            "title": "Ballot Choices"
+          },
+          "submitted_by": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 128
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Submitted By"
+          }
+        },
+        "type": "object",
+        "required": [
+          "meeting_id",
+          "shareholder_id",
+          "ballot_choices"
+        ],
+        "title": "ProxyVoteCreate"
+      },
+      "ProxyVoteRead": {
+        "properties": {
+          "meeting_id": {
+            "type": "string",
+            "maxLength": 64,
+            "title": "Meeting Id"
+          },
+          "shareholder_id": {
+            "type": "string",
+            "maxLength": 36,
+            "title": "Shareholder Id"
+          },
+          "ballot_choices": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object",
+            "title": "Ballot Choices"
+          },
+          "submitted_by": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 128
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Submitted By"
+          },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "tenant_id": {
+            "type": "string",
+            "title": "Tenant Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "meeting_id",
+          "shareholder_id",
+          "ballot_choices",
+          "id",
+          "tenant_id"
+        ],
+        "title": "ProxyVoteRead"
+      },
+      "ProxyVoteSummary": {
+        "properties": {
+          "meeting_id": {
+            "type": "string",
+            "title": "Meeting Id"
+          },
+          "totals": {
+            "additionalProperties": {
+              "additionalProperties": {
+                "type": "integer"
+              },
+              "type": "object"
+            },
+            "type": "object",
+            "title": "Totals"
+          },
+          "total_ballots": {
+            "type": "integer",
+            "title": "Total Ballots"
+          }
+        },
+        "type": "object",
+        "required": [
+          "meeting_id",
+          "totals",
+          "total_ballots"
+        ],
+        "title": "ProxyVoteSummary"
+      },
+      "RefreshRequest": {
+        "properties": {
+          "refresh_token": {
+            "type": "string",
+            "title": "Refresh Token"
+          }
+        },
+        "type": "object",
+        "required": [
+          "refresh_token"
+        ],
+        "title": "RefreshRequest"
+      },
+      "ShareholderCreate": {
+        "properties": {
+          "external_ref": {
+            "type": "string",
+            "maxLength": 128,
+            "title": "External Ref"
+          },
+          "full_name": {
+            "type": "string",
+            "maxLength": 255,
+            "title": "Full Name"
+          },
+          "email": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 320
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Email"
+          },
+          "phone_number": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 32
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Phone Number"
+          },
+          "type": {
+            "$ref": "#/components/schemas/ShareholderType",
+            "default": "INDIVIDUAL"
+          },
+          "total_shares": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "title": "Total Shares",
+            "default": "0"
+          },
+          "profile": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Profile"
+          }
+        },
+        "type": "object",
+        "required": [
+          "external_ref",
+          "full_name"
+        ],
+        "title": "ShareholderCreate"
+      },
+      "ShareholderRead": {
+        "properties": {
+          "external_ref": {
+            "type": "string",
+            "maxLength": 128,
+            "title": "External Ref"
+          },
+          "full_name": {
+            "type": "string",
+            "maxLength": 255,
+            "title": "Full Name"
+          },
+          "email": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 320
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Email"
+          },
+          "phone_number": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 32
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Phone Number"
+          },
+          "type": {
+            "$ref": "#/components/schemas/ShareholderType",
+            "default": "INDIVIDUAL"
+          },
+          "total_shares": {
+            "type": "string",
+            "title": "Total Shares",
+            "default": "0"
+          },
+          "profile": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Profile"
+          },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "tenant_id": {
+            "type": "string",
+            "title": "Tenant Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "external_ref",
+          "full_name",
+          "id",
+          "tenant_id"
+        ],
+        "title": "ShareholderRead"
+      },
+      "ShareholderType": {
+        "type": "string",
+        "enum": [
+          "INDIVIDUAL",
+          "INSTITUTION"
+        ],
+        "title": "ShareholderType"
+      },
+      "ShareholderUpdate": {
+        "properties": {
+          "full_name": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 255
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Full Name"
+          },
+          "email": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 320
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Email"
+          },
+          "phone_number": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 32
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Phone Number"
+          },
+          "type": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ShareholderType"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "total_shares": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Total Shares"
+          },
+          "profile": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Profile"
+          }
+        },
+        "type": "object",
+        "title": "ShareholderUpdate"
+      },
+      "TokenResponse": {
+        "properties": {
+          "access_token": {
+            "type": "string",
+            "title": "Access Token"
+          },
+          "refresh_token": {
+            "type": "string",
+            "title": "Refresh Token"
+          },
+          "token_type": {
+            "type": "string",
+            "title": "Token Type",
+            "default": "bearer"
+          },
+          "expires_in": {
+            "type": "integer",
+            "title": "Expires In"
+          }
+        },
+        "type": "object",
+        "required": [
+          "access_token",
+          "refresh_token",
+          "expires_in"
+        ],
+        "title": "TokenResponse"
+      },
+      "TransactionStatus": {
+        "type": "string",
+        "enum": [
+          "PENDING",
+          "SENT",
+          "SETTLED",
+          "FAILED"
+        ],
+        "title": "TransactionStatus"
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "type": "array",
+            "title": "Location"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Message"
+          },
+          "type": {
+            "type": "string",
+            "title": "Error Type"
+          }
+        },
+        "type": "object",
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError"
+      }
+    },
+    "securitySchemes": {
+      "HTTPBearer": {
+        "type": "http",
+        "scheme": "bearer"
+      }
+    }
+  }
+}

--- a/docs/runbooks/data-retention.md
+++ b/docs/runbooks/data-retention.md
@@ -1,0 +1,29 @@
+# Data Retention Runbook
+
+## Overview
+The data retention worker purges aged audit logs and financial transactions from Postgres and applies S3 lifecycle policies for uploaded shareholder artifacts. Metrics are emitted through Prometheus counters and tracing is forwarded via OpenTelemetry.
+
+## Dashboards & Alerts
+- **Grafana**: `docs/dashboards/data-retention-dashboard.json` visualises hourly deletions and job duration.
+- **Alerts**: Configure warning when `data_retention_transactions_deleted_total` remains flat for 24h or the worker stops reporting traces.
+
+## Run Procedure
+1. **Validate configuration**
+   - Retention windows are set via environment variables: `AUDIT_LOG_RETENTION_DAYS`, `TRANSACTION_RETENTION_DAYS`, `UPLOAD_RETENTION_DAYS`.
+   - Ensure the OTLP endpoint (`OTEL_EXPORTER_ENDPOINT`) matches the collector deployment.
+2. **Start the worker**
+   ```bash
+   python -m workers.data_retention.main
+   ```
+   The worker logs summary statistics every cycle and exports metrics at `/metrics` on the main API service.
+3. **Verify impact**
+   - Check Prometheus counters `data_retention_audit_logs_deleted_total` and `data_retention_transactions_deleted_total` incrementing.
+   - Inspect spans in the tracing backend for `data_retention.cycle` to ensure context propagation.
+
+## Failure Recovery
+- If the worker crashes, restart the process and review logs for database connectivity errors.
+- For S3 lifecycle issues, apply the generated policy from `DataRetentionService.build_s3_lifecycle_policy()` using Terraform or the AWS CLI.
+- Re-run the worker in catch-up mode by temporarily lowering `DATA_RETENTION_INTERVAL_SECONDS` to 300 seconds.
+
+## Escalation
+- If deletions stall for more than one cycle despite backlog, escalate to the database administrator with the latest job logs and metrics snapshot.

--- a/docs/runbooks/observability.md
+++ b/docs/runbooks/observability.md
@@ -1,0 +1,36 @@
+# Observability Runbook
+
+## Metrics
+- Prometheus endpoint exposed at `https://<host>/metrics` via `PrometheusMiddleware`.
+- Key metrics:
+  - `http_request_latency_seconds` (histogram) for API latency percentiles.
+  - `http_requests_total` and `http_request_errors_total` for rate/error monitoring.
+  - `worker_queue_depth{queue_name=...}` for SQS/Kafka backlog visibility.
+  - `data_retention_*` counters for nightly purge totals.
+
+## Tracing
+- Tracing initialised via `initialise_tracing` with OTLP exporter targeting `OTEL_EXPORTER_ENDPOINT`.
+- FastAPI, SQLAlchemy, and worker spans propagate `traceparent` headers end-to-end.
+- Workers use `worker_span` to link queue messages back to originating API calls.
+
+## Dashboards & Alerts
+- Import `docs/dashboards/observability-dashboard.json` into Grafana.
+- Recommended alerts:
+  - P95 latency > 2s for 5 minutes.
+  - Error rate > 5% for 5 minutes.
+  - Queue depth > threshold for >10 minutes.
+
+## Troubleshooting Steps
+1. **Check Metrics** – query Prometheus for `sum(rate(http_request_errors_total[5m]))`.
+2. **Inspect Traces** – search for the `trace_id` from the `X-Request-ID` header in the tracing backend.
+3. **Review Logs** – structured audit logs stored in S3 bucket `AUDIT_LOG_BUCKET` with prefix `AUDIT_LOG_PREFIX`.
+4. **Validate Instrumentation** – run unit tests `tests/unit/test_observability.py` to ensure instrumentation is functioning.
+
+## Useful Commands
+```bash
+uvicorn app.main:app --reload --port 8000
+pytest --cov=app --cov-report=term-missing
+python scripts/generate_openapi.py
+python -m workers.upload_validator.main
+python -m workers.transaction_reporting.main
+```

--- a/infra/helm/README.md
+++ b/infra/helm/README.md
@@ -1,0 +1,25 @@
+# Fintech Helm Chart
+
+This chart deploys the Fintech FastAPI service with Prometheus metrics, OpenTelemetry tracing, and optional blue/green rollouts.
+
+## Usage
+```bash
+helm dependency update infra/helm/fintech
+helm template fintech infra/helm/fintech \
+  --set image.repository=ghcr.io/your-org/fintech \
+  --set image.tag=sha-abcdef \
+  --set blueGreen.enabled=true \
+  --set blueGreen.activeColor=green
+```
+
+## Values
+- `replicaCount`: number of pods for the active colour (default 2).
+- `hpa.enabled`: toggles autoscaling using CPU utilisation.
+- `blueGreen.enabled`: when true, the Service targets `blueGreen.activeColor` and a standby deployment is created using `blueGreen.standbyColor`.
+- `env`: map of environment variables injected into the container.
+
+## Files
+- `templates/deployment.yaml` – primary deployment (defaults to `blue`).
+- `templates/deployment-standby.yaml` – standby deployment when blue/green is enabled.
+- `templates/service.yaml` – ClusterIP service exposing port 80.
+- `templates/hpa.yaml` – optional HorizontalPodAutoscaler.

--- a/infra/helm/fintech/Chart.yaml
+++ b/infra/helm/fintech/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: fintech
+version: 0.1.0
+description: Helm chart for the Fintech API deployment
+appVersion: "0.1.0"

--- a/infra/helm/fintech/templates/_helpers.tpl
+++ b/infra/helm/fintech/templates/_helpers.tpl
@@ -1,0 +1,18 @@
+{{- define "fintech.name" -}}
+{{- default .Chart.Name .Values.nameOverride -}}
+{{- end -}}
+
+{{- define "fintech.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name (include "fintech.name" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "fintech.labels" -}}
+app.kubernetes.io/name: {{ include "fintech.name" . }}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}

--- a/infra/helm/fintech/templates/deployment-standby.yaml
+++ b/infra/helm/fintech/templates/deployment-standby.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.blueGreen.enabled }}
+{{- $color := .Values.blueGreen.standbyColor -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "fintech.fullname" . }}-{{ $color }}
+  labels:
+    {{- include "fintech.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api
+    app.kubernetes.io/version: {{ $color }}
+spec:
+  replicas: {{ .Values.blueGreen.standbyReplicas }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "fintech.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      version: {{ $color }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "fintech.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        version: {{ $color }}
+    spec:
+      containers:
+        - name: api
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: 8000
+              name: http
+          env:
+            {{- range $key, $value := .Values.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+{{- end }}

--- a/infra/helm/fintech/templates/deployment.yaml
+++ b/infra/helm/fintech/templates/deployment.yaml
@@ -1,0 +1,52 @@
+{{- $color := "blue" -}}
+{{- if .Values.blueGreen.enabled -}}
+{{- $color = .Values.blueGreen.activeColor -}}
+{{- end -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "fintech.fullname" . }}-{{ $color }}
+  labels:
+    {{- include "fintech.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api
+    app.kubernetes.io/version: {{ $color }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "fintech.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      version: {{ $color }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "fintech.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        version: {{ $color }}
+    spec:
+      containers:
+        - name: api
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: 8000
+              name: http
+          env:
+            {{- range $key, $value := .Values.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          readinessProbe:
+            httpGet:
+              path: /api/readyz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /api/healthz
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 20

--- a/infra/helm/fintech/templates/hpa.yaml
+++ b/infra/helm/fintech/templates/hpa.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.hpa.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "fintech.fullname" . }}
+  labels:
+    {{- include "fintech.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "fintech.fullname" . }}-{{ if .Values.blueGreen.enabled }}{{ .Values.blueGreen.activeColor }}{{ else }}blue{{ end }}
+  minReplicas: {{ .Values.hpa.minReplicas }}
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.hpa.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/infra/helm/fintech/templates/service.yaml
+++ b/infra/helm/fintech/templates/service.yaml
@@ -1,0 +1,21 @@
+{{- $color := "blue" -}}
+{{- if .Values.blueGreen.enabled -}}
+{{- $color = .Values.blueGreen.activeColor -}}
+{{- end -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "fintech.fullname" . }}
+  labels:
+    {{- include "fintech.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+  selector:
+    app.kubernetes.io/name: {{ include "fintech.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    version: {{ $color }}

--- a/infra/helm/fintech/values.yaml
+++ b/infra/helm/fintech/values.yaml
@@ -1,0 +1,35 @@
+image:
+  repository: ghcr.io/example/fintech
+  tag: latest
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 80
+
+resources:
+  limits:
+    cpu: 500m
+    memory: 512Mi
+  requests:
+    cpu: 250m
+    memory: 256Mi
+
+env:
+  APP_NAME: "Fintech API"
+  ENABLE_METRICS: "true"
+  ENABLE_TRACING: "true"
+
+replicaCount: 2
+
+hpa:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 70
+
+blueGreen:
+  enabled: false
+  activeColor: blue
+  standbyColor: green
+  standbyReplicas: 0

--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -1,0 +1,23 @@
+# Terraform Stubs
+
+This module provisions S3 buckets with lifecycle policies that match the `DataRetentionService` defaults and deploys the Helm chart.
+
+## Usage
+```hcl
+module "fintech" {
+  source = "./infra/terraform"
+
+  aws_region          = "us-east-1"
+  audit_log_bucket    = "fintech-audit-logs"
+  upload_bucket       = "fintech-uploads"
+  image_repository    = "ghcr.io/your-org/fintech"
+  image_tag           = "v0.1.0"
+  upload_retention_days = 365
+}
+```
+
+Run:
+```bash
+terraform init
+terraform plan
+```

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -1,0 +1,72 @@
+terraform {
+  required_version = ">= 1.4.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.21"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.11"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+resource "aws_s3_bucket" "audit_logs" {
+  bucket = var.audit_log_bucket
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "audit_logs" {
+  bucket = aws_s3_bucket.audit_logs.id
+
+  rule {
+    id     = "expire-audit-logs"
+    status = "Enabled"
+
+    expiration {
+      days = var.upload_retention_days
+    }
+  }
+}
+
+resource "aws_s3_bucket" "uploads" {
+  bucket = var.upload_bucket
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "uploads" {
+  bucket = aws_s3_bucket.uploads.id
+
+  rule {
+    id     = "expire-shareholder-uploads"
+    status = "Enabled"
+
+    expiration {
+      days = var.upload_retention_days
+    }
+  }
+}
+
+resource "helm_release" "fintech" {
+  name       = var.release_name
+  chart      = "../helm/fintech"
+  namespace  = var.namespace
+  create_namespace = true
+
+  set {
+    name  = "image.repository"
+    value = var.image_repository
+  }
+
+  set {
+    name  = "image.tag"
+    value = var.image_tag
+  }
+}

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -1,0 +1,9 @@
+output "audit_log_bucket" {
+  description = "Audit log S3 bucket"
+  value       = aws_s3_bucket.audit_logs.bucket
+}
+
+output "upload_bucket" {
+  description = "Upload S3 bucket"
+  value       = aws_s3_bucket.uploads.bucket
+}

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -1,0 +1,47 @@
+variable "aws_region" {
+  type        = string
+  description = "AWS region for resources"
+  default     = "us-east-1"
+}
+
+variable "audit_log_bucket" {
+  type        = string
+  description = "S3 bucket name for audit logs"
+  default     = "fintech-audit-logs"
+}
+
+variable "upload_bucket" {
+  type        = string
+  description = "S3 bucket for shareholder uploads"
+  default     = "fintech-uploads"
+}
+
+variable "upload_retention_days" {
+  type        = number
+  description = "Retention window for uploads and audit logs"
+  default     = 180
+}
+
+variable "release_name" {
+  type        = string
+  description = "Helm release name"
+  default     = "fintech"
+}
+
+variable "namespace" {
+  type        = string
+  description = "Kubernetes namespace"
+  default     = "fintech"
+}
+
+variable "image_repository" {
+  type        = string
+  description = "Container image repository"
+  default     = "ghcr.io/example/fintech"
+}
+
+variable "image_tag" {
+  type        = string
+  description = "Container image tag"
+  default     = "latest"
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dev = [
   "pytest>=7.4.0",
   "pytest-asyncio>=0.21.0",
   "pytest-cov>=4.1.0",
+  "pre-commit>=3.4.0",
 ]
 
 [tool.black]

--- a/scripts/generate_openapi.py
+++ b/scripts/generate_openapi.py
@@ -1,0 +1,25 @@
+"""Utility script to export the FastAPI OpenAPI specification."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from app.main import create_application
+
+
+def main() -> None:
+    app = create_application()
+    spec = app.openapi()
+    destination = Path("docs/openapi.json")
+    destination.write_text(json.dumps(spec, indent=2), encoding="utf-8")
+    print(f"OpenAPI specification written to {destination}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -186,10 +186,15 @@ def _transaction_event_publisher_stub(monkeypatch: pytest.MonkeyPatch) -> Iterat
 
     class DummyKafkaProducer:
         def __init__(self, *_: object, **__: object) -> None:
-            self.messages: list[dict[str, str]] = []
+            self.messages: list[dict[str, object]] = []
 
-        def send(self, topic: str, value: dict[str, str]) -> None:
-            self.messages.append({"topic": topic, "value": json.dumps(value)})
+        def send(
+            self,
+            topic: str,
+            value: dict[str, str],
+            headers: list[tuple[str, bytes]] | None = None,
+        ) -> None:
+            self.messages.append({"topic": topic, "value": json.dumps(value), "headers": headers})
 
         def flush(self) -> None:  # pragma: no cover - compatibility shim
             return None

--- a/tests/unit/test_data_retention.py
+++ b/tests/unit/test_data_retention.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from sqlalchemy.orm import Session
+
+from app.models import AuditLog, Transaction, TransactionStatus, TransactionType
+from app.services.data_retention import DataRetentionService
+
+
+def _make_audit_log(session: Session, *, created_at: datetime) -> None:
+    log = AuditLog(
+        tenant_id="tenant-demo",
+        actor_id=None,
+        action="TEST",
+        resource_type="demo",
+        resource_id="1",
+        payload={"field": "value"},
+        ip_address="127.0.0.1",
+        created_at=created_at,
+        updated_at=created_at,
+    )
+    session.add(log)
+
+
+def _make_transaction(session: Session, *, created_at: datetime) -> None:
+    txn = Transaction(
+        tenant_id="tenant-demo",
+        shareholder_id=None,
+        plan_id=None,
+        amount=100,
+        currency="USD",
+        type=TransactionType.DIVIDEND,
+        status=TransactionStatus.SETTLED,
+        reference="ref",
+        details={},
+        created_at=created_at,
+        updated_at=created_at,
+    )
+    session.add(txn)
+
+
+def test_data_retention_deletes_expired_records(db_session: Session) -> None:
+    now = datetime.now(tz=UTC)
+    old_timestamp = now - timedelta(days=400)
+    new_timestamp = now - timedelta(days=10)
+
+    _make_audit_log(db_session, created_at=old_timestamp)
+    _make_audit_log(db_session, created_at=new_timestamp)
+    _make_transaction(db_session, created_at=old_timestamp)
+    _make_transaction(db_session, created_at=new_timestamp)
+    db_session.commit()
+
+    service = DataRetentionService(session=db_session)
+    report = service.purge_expired_records(now=now)
+    db_session.commit()
+
+    remaining_audit = db_session.query(AuditLog).count()
+    remaining_transactions = db_session.query(Transaction).count()
+
+    assert report.audit_logs_deleted == 1
+    assert report.transactions_deleted == 1
+    assert remaining_audit == 1
+    assert remaining_transactions == 1
+
+
+def test_s3_lifecycle_policy_uses_configured_prefix(db_session: Session) -> None:
+    service = DataRetentionService(session=db_session)
+    policy = service.build_s3_lifecycle_policy()
+
+    rule_ids = {rule["ID"] for rule in policy["Rules"]}
+    assert "expire-audit-logs" in rule_ids
+    assert "expire-shareholder-uploads" in rule_ids

--- a/tests/unit/test_observability.py
+++ b/tests/unit/test_observability.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from opentelemetry import trace
+
+from app.obs import (
+    QUEUE_DEPTH_GAUGE,
+    PrometheusMiddleware,
+    initialise_tracing,
+    inject_traceparent,
+    metrics_router,
+    report_queue_depth,
+    span_from_traceparent,
+)
+
+
+def test_metrics_endpoint_exposes_counters() -> None:
+    app = FastAPI()
+    app.add_middleware(PrometheusMiddleware)
+    app.include_router(metrics_router)
+
+    client = TestClient(app)
+    response = client.get("/metrics")
+
+    assert response.status_code == 200
+    assert "http_requests_total" in response.text
+
+
+def test_report_queue_depth_updates_gauge() -> None:
+    report_queue_depth("test-queue", 7)
+    sample_family = next(iter(QUEUE_DEPTH_GAUGE.collect()))
+    sample = next(
+        item for item in sample_family.samples if item.labels["queue_name"] == "test-queue"
+    )
+    assert sample.value == 7
+
+
+def test_span_from_traceparent_links_context() -> None:
+    initialise_tracing(service_name="unit-test-service")
+    tracer = trace.get_tracer(__name__)
+    with tracer.start_as_current_span("parent"):
+        carrier = inject_traceparent({})
+    traceparent = carrier.get("traceparent")
+    assert traceparent is not None
+
+    with span_from_traceparent("child", traceparent) as span:
+        assert (
+            span.get_span_context().trace_id == trace.get_current_span().get_span_context().trace_id
+        )

--- a/workers/data_retention/__init__.py
+++ b/workers/data_retention/__init__.py
@@ -1,0 +1,3 @@
+"""Data retention worker package."""
+
+__all__ = []

--- a/workers/data_retention/main.py
+++ b/workers/data_retention/main.py
@@ -1,0 +1,60 @@
+"""Asynchronous worker executing data retention policies."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import UTC, datetime
+
+from app.core.config import get_settings
+from app.db.session import SessionLocal
+from app.obs import DATA_RETENTION_AUDIT_COUNTER, DATA_RETENTION_TRANSACTION_COUNTER
+from app.services.data_retention import DataRetentionService
+from app.workers.observability import configure_worker, worker_span
+
+LOGGER = logging.getLogger(__name__)
+
+
+async def run_once(service: DataRetentionService) -> None:
+    """Execute a single retention cycle."""
+
+    with worker_span("data_retention.cycle"):
+        report = service.purge_expired_records(now=datetime.now(tz=UTC))
+        if report.audit_logs_deleted:
+            DATA_RETENTION_AUDIT_COUNTER.inc(report.audit_logs_deleted)
+        if report.transactions_deleted:
+            DATA_RETENTION_TRANSACTION_COUNTER.inc(report.transactions_deleted)
+        LOGGER.info(
+            "data retention cycle complete",
+            extra={
+                "audit_logs_deleted": report.audit_logs_deleted,
+                "transactions_deleted": report.transactions_deleted,
+            },
+        )
+
+
+async def run() -> None:
+    """Continuously run data retention cycles at the configured cadence."""
+
+    settings = get_settings()
+    configure_worker("data-retention-worker", queues=["data-retention"])
+    interval = max(60, settings.data_retention_interval_seconds)
+    LOGGER.info("starting data retention worker", extra={"interval_seconds": interval})
+    while True:
+        with SessionLocal() as session:  # type: ignore[attr-defined]
+            service = DataRetentionService(session=session, settings=settings)
+            await run_once(service)
+            session.commit()
+        await asyncio.sleep(interval)
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO)
+    try:
+        asyncio.run(run())
+    except KeyboardInterrupt:  # pragma: no cover - manual shutdown
+        LOGGER.info("data retention worker stopped")
+
+
+if __name__ == "__main__":
+    main()

--- a/workers/dividend_worker/main.py
+++ b/workers/dividend_worker/main.py
@@ -1,22 +1,38 @@
-"""Placeholder dividend processing worker."""
+"""Dividend processing worker with observability instrumentation."""
+
+from __future__ import annotations
 
 import asyncio
+import logging
+
+from app.obs import report_queue_depth
+from app.workers.observability import configure_worker, worker_span
+
+LOGGER = logging.getLogger(__name__)
+QUEUE_NAME = "dividend-distributions"
 
 
 async def run() -> None:
     """Simulate long running dividend distribution processing."""
 
+    configure_worker("dividend-worker", queues=[QUEUE_NAME])
+    backlog = 0
     while True:
+        with worker_span("dividend.tick", queue_depth=backlog):
+            LOGGER.debug("processing dividend cycle", extra={"queue_depth": backlog})
+            report_queue_depth(QUEUE_NAME, backlog)
+            backlog = max(0, backlog - 1)
         await asyncio.sleep(60)
 
 
 def main() -> None:
     """Entry point for the dividend worker."""
 
+    logging.basicConfig(level=logging.INFO)
     try:
         asyncio.run(run())
     except KeyboardInterrupt:
-        pass
+        LOGGER.info("dividend worker stopped")
 
 
 if __name__ == "__main__":

--- a/workers/transaction_reporting/main.py
+++ b/workers/transaction_reporting/main.py
@@ -1,13 +1,17 @@
 """Worker consuming Kafka transaction events into reporting tables."""
+
 from __future__ import annotations
 
 import asyncio
 import logging
 
 from app.db.session import SessionLocal
+from app.obs import report_queue_depth
 from app.services.transaction_events import TransactionEventConsumer
+from app.workers.observability import configure_worker, worker_span
 
 logger = logging.getLogger(__name__)
+QUEUE_NAME = "transaction-events"
 
 
 class TransactionReportingWorker:
@@ -19,12 +23,16 @@ class TransactionReportingWorker:
     async def run_forever(self) -> None:
         logger.info("transaction reporting worker started")
         while True:
-            processed = await asyncio.to_thread(self._consumer.poll_once)
+            with worker_span("transaction_reporting.poll"):
+                processed = await asyncio.to_thread(self._consumer.poll_once)
+                depth = 0 if processed else 1
+                report_queue_depth(QUEUE_NAME, depth)
             if not processed:
                 await asyncio.sleep(1)
 
 
 async def run() -> None:
+    configure_worker("transaction-reporting-worker", queues=[QUEUE_NAME])
     worker = TransactionReportingWorker()
     await worker.run_forever()
 


### PR DESCRIPTION
## Summary
- instrument the FastAPI service and workers with Prometheus metrics, OpenTelemetry tracing helpers, and queue depth reporting
- add a data retention service/worker with automated tests plus generated OpenAPI spec, dashboards, ADRs, and runbooks
- introduce Helm and Terraform deployment stubs (including HPA and blue/green support) and expand CI to lint, type-check, test, build, and dry-run Helm

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dccac6f53c8328968e4029b75a13ef